### PR TITLE
feat(wedu): 참여 중인 같이방 영역 접기/펼치기 기능 추가

### DIFF
--- a/lib/screens/wedu/wedu_home.dart
+++ b/lib/screens/wedu/wedu_home.dart
@@ -5,6 +5,7 @@ import 'package:peeroreum_client/designs/PeeroreumToast.dart';
 import 'package:get/get.dart';
 import 'package:peeroreum_client/api/ApiClient.dart';
 import 'package:peeroreum_client/designs/PeeroreumColor.dart';
+import 'package:peeroreum_client/designs/PeeroreumTypo.dart';
 import 'package:peeroreum_client/screens/alert/alert_view.dart';
 import 'package:peeroreum_client/screens/wedu/wedu_create_screen.dart';
 import 'package:peeroreum_client/screens/wedu/wedu_in.dart';
@@ -295,83 +296,104 @@ class _HomeWeduState extends State<HomeWedu> {
   Widget bodyWidget() {
     return Column(
       children: [
-        if (inRoomData.isNotEmpty) ...[
-          GestureDetector(
-            behavior: HitTestBehavior.translucent,
-            onVerticalDragEnd: (details) {
-              final dy = details.velocity.pixelsPerSecond.dy;
-              if (dy < -200 && _isUp) {
-                setState(() => _isUp = false);
-              } else if (dy > 200 && !_isUp) {
-                setState(() => _isUp = true);
-              }
-            },
-            child: Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Row(
-                        children: [
-                          const Text(
-                            "참여 중인 같이방",
-                            style: TextStyle(
-                              color: PeeroreumColor.black,
-                              fontFamily: 'Pretendard',
-                              fontSize: 18,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            '${inRoomData.length}',
-                            style: TextStyle(
-                              fontFamily: 'Pretendard',
-                              fontSize: 18,
-                              fontWeight: FontWeight.w600,
-                              color: PeeroreumColor.gray[600],
-                            ),
-                          ),
-                        ],
-                      ),
-                      GestureDetector(
-                        onTap: () => Get.to(() => const InWedu()),
-                        child: Text(
-                          '전체보기',
+        GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onVerticalDragEnd: (details) {
+            final dy = details.velocity.pixelsPerSecond.dy;
+            if (dy < -200 && _isUp) {
+              setState(() => _isUp = false);
+            } else if (dy > 200 && !_isUp) {
+              setState(() => _isUp = true);
+            }
+          },
+          child: Column(
+            children: [
+              Padding(
+                padding:
+                    const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Row(
+                      children: [
+                        T3_18px(
+                          text: '참여 중인 같이방',
+                          color: PeeroreumColor.gray[800],
+                        ),
+                        const SizedBox(width: 4),
+                        Text(
+                          '${inRoomData.length}',
                           style: TextStyle(
                             fontFamily: 'Pretendard',
+                            fontSize: 18,
                             fontWeight: FontWeight.w600,
-                            fontSize: 14,
-                            color: PeeroreumColor.gray[500],
+                            color: PeeroreumColor.gray[600],
                           ),
                         ),
-                      ),
-                    ],
-                  ),
-                ),
-                AnimatedContainer(
-                  duration: const Duration(milliseconds: 150),
-                  curve: Curves.easeInOut,
-                  height: _isUp ? 200 : 0,
-                  child: ClipRect(
-                    child: OverflowBox(
-                      maxHeight: 200,
-                      alignment: Alignment.topCenter,
-                      child: Column(
-                        children: [
-                          SizedBox(height: 180, child: inRoomBody()),
-                          const SizedBox(height: 20),
-                        ],
+                      ],
+                    ),
+                    GestureDetector(
+                      onTap: () => Get.to(() => const InWedu()),
+                      child: Text(
+                        '전체보기',
+                        style: TextStyle(
+                          fontFamily: 'Pretendard',
+                          fontWeight: FontWeight.w600,
+                          fontSize: 14,
+                          color: PeeroreumColor.gray[500],
+                        ),
                       ),
                     ),
+                  ],
+                ),
+              ),
+              AnimatedContainer(
+                duration: const Duration(milliseconds: 150),
+                curve: Curves.easeInOut,
+                height: _isUp ? 200 : 0,
+                child: ClipRect(
+                  child: OverflowBox(
+                    maxHeight: 200,
+                    alignment: Alignment.topCenter,
+                    child: inRoomData.isEmpty
+                        ? SizedBox(
+                            height: 200,
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                const T4_16px(
+                                    text: '참여 중인 같이방이 없어요',
+                                    color: PeeroreumColor.black),
+                                const SizedBox(height: 20),
+                                GestureDetector(
+                                  onTap: () => Get.to(() => CreateWedu()),
+                                  child: Container(
+                                    padding: const EdgeInsets.symmetric(
+                                        vertical: 8, horizontal: 16),
+                                    decoration: BoxDecoration(
+                                      color: PeeroreumColor.primaryPuple[400],
+                                      borderRadius: BorderRadius.circular(8),
+                                    ),
+                                    child: const T4_16px(
+                                        text: '같이방 만들러 가기',
+                                        color: PeeroreumColor.white),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          )
+                        : Column(
+                            children: [
+                              SizedBox(height: 180, child: inRoomBody()),
+                              const SizedBox(height: 20),
+                            ],
+                          ),
                   ),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
-        ],
+        ),
         GestureDetector(
           behavior: HitTestBehavior.translucent,
           onVerticalDragEnd: (details) {
@@ -426,17 +448,7 @@ class _HomeWeduState extends State<HomeWedu> {
           padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                '같이방',
-                style: TextStyle(
-                  color: PeeroreumColor.gray[800],
-                  fontSize: 18,
-                  fontWeight: FontWeight.w600,
-                  fontFamily: 'Pretendard',
-                ),
-              ),
-            ],
+            children: [T3_18px(text: '같이방', color: PeeroreumColor.gray[800])],
           ),
         ),
         dropDownBody(),
@@ -1197,4 +1209,3 @@ class _HomeWeduState extends State<HomeWedu> {
     super.dispose();
   }
 }
-

--- a/lib/screens/wedu/wedu_home.dart
+++ b/lib/screens/wedu/wedu_home.dart
@@ -77,7 +77,7 @@ class _HomeWeduState extends State<HomeWedu> {
           !_isLoading) {
         loadMoreData();
       }
-      if (_scrollController.offset ==
+      if (_scrollController.offset <=
           _scrollController.position.minScrollExtent) {
         setState(() {
           _isUp = true;
@@ -293,75 +293,124 @@ class _HomeWeduState extends State<HomeWedu> {
   }
 
   Widget bodyWidget() {
-    return Scaffold(
-      backgroundColor: PeeroreumColor.white,
-      appBar: roomBody(),
-      body: NestedScrollView(
-          physics: const AlwaysScrollableScrollPhysics(),
-          headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
-            return <Widget>[
-              if (inRoomData.isNotEmpty)
-                SliverAppBar(
-                  expandedHeight: 200,
-                  pinned: false,
-                  floating: true,
-                  backgroundColor: PeeroreumColor.white,
-                  elevation: 0,
-                  flexibleSpace: LayoutBuilder(
-                    builder:
-                        (BuildContext context, BoxConstraints constraints) {
-                      return FlexibleSpaceBar(
-                        collapseMode: CollapseMode.parallax,
-                        background: Column(
-                          children: [
-                            SizedBox(
-                              height: 180,
-                              child: inRoomBody(),
+    return Column(
+      children: [
+        if (inRoomData.isNotEmpty) ...[
+          GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onVerticalDragEnd: (details) {
+              final dy = details.velocity.pixelsPerSecond.dy;
+              if (dy < -200 && _isUp) {
+                setState(() => _isUp = false);
+              } else if (dy > 200 && !_isUp) {
+                setState(() => _isUp = true);
+              }
+            },
+            child: Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Row(
+                        children: [
+                          const Text(
+                            "참여 중인 같이방",
+                            style: TextStyle(
+                              color: PeeroreumColor.black,
+                              fontFamily: 'Pretendard',
+                              fontSize: 18,
+                              fontWeight: FontWeight.w600,
                             ),
-                            const SizedBox(
-                              height: 20,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            '${inRoomData.length}',
+                            style: TextStyle(
+                              fontFamily: 'Pretendard',
+                              fontSize: 18,
+                              fontWeight: FontWeight.w600,
+                              color: PeeroreumColor.gray[600],
                             ),
-                          ],
+                          ),
+                        ],
+                      ),
+                      GestureDetector(
+                        onTap: () => Get.to(() => const InWedu()),
+                        child: Text(
+                          '전체보기',
+                          style: TextStyle(
+                            fontFamily: 'Pretendard',
+                            fontWeight: FontWeight.w600,
+                            fontSize: 14,
+                            color: PeeroreumColor.gray[500],
+                          ),
                         ),
-                      );
-                    },
+                      ),
+                    ],
                   ),
                 ),
-            ];
-          },
-          body: data.isEmpty
-              ? Column(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    sliver(),
-                    Image.asset(
-                      'assets/images/no_wedu_oreum.png',
-                      width: 150,
-                    ),
-                    const Text(
-                      '찾으시는 같이방이 없어요 🥲',
-                      style: TextStyle(
-                        fontFamily: 'Pretendard',
-                        fontSize: 20,
-                        fontWeight: FontWeight.w600,
-                        color: PeeroreumColor.black,
+                AnimatedContainer(
+                  duration: const Duration(milliseconds: 150),
+                  curve: Curves.easeInOut,
+                  height: _isUp ? 200 : 0,
+                  child: ClipRect(
+                    child: OverflowBox(
+                      maxHeight: 200,
+                      alignment: Alignment.topCenter,
+                      child: Column(
+                        children: [
+                          SizedBox(height: 180, child: inRoomBody()),
+                          const SizedBox(height: 20),
+                        ],
                       ),
                     ),
-                  ],
-                )
-              : Column(
-                  children: [
-                    sliver(),
-                    Container(
-                      height: _isUp ? 0 : 1,
-                      color: PeeroreumColor.gray[200],
-                    ),
-                    Expanded(child: listViewBody()),
-                    const SizedBox(
-                      height: 8,
-                    ),
-                  ],
-                )),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+        GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onVerticalDragEnd: (details) {
+            final dy = details.velocity.pixelsPerSecond.dy;
+            if (dy < -200 && _isUp) {
+              setState(() => _isUp = false);
+            } else if (dy > 200 && !_isUp) {
+              setState(() => _isUp = true);
+            }
+          },
+          child: sliver(),
+        ),
+        Container(height: _isUp ? 0 : 1, color: PeeroreumColor.gray[200]),
+        if (data.isEmpty)
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Image.asset(
+                  'assets/images/no_wedu_oreum.png',
+                  width: 150,
+                ),
+                const Text(
+                  '찾으시는 같이방이 없어요 🥲',
+                  style: TextStyle(
+                    fontFamily: 'Pretendard',
+                    fontSize: 20,
+                    fontWeight: FontWeight.w600,
+                    color: PeeroreumColor.black,
+                  ),
+                ),
+              ],
+            ),
+          )
+        else ...[
+          Expanded(child: listViewBody()),
+          const SizedBox(height: 8),
+        ],
+      ],
     );
   }
 
@@ -392,58 +441,6 @@ class _HomeWeduState extends State<HomeWedu> {
         ),
         dropDownBody(),
       ],
-    );
-  }
-
-  PreferredSizeWidget roomBody() {
-    return AppBar(
-      backgroundColor: PeeroreumColor.white,
-      shadowColor: Colors.transparent,
-      surfaceTintColor: Colors.transparent,
-      elevation: 0,
-      titleSpacing: 0,
-      automaticallyImplyLeading: false,
-      title: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Row(
-              children: [
-                const Text(
-                  "참여 중인 같이방",
-                  style: TextStyle(
-                      color: PeeroreumColor.black,
-                      fontFamily: 'Pretendard',
-                      fontSize: 18,
-                      fontWeight: FontWeight.w600),
-                ),
-                const SizedBox(
-                  width: 4,
-                ),
-                Text(
-                  '${inRoomData.length}',
-                  style: TextStyle(
-                      fontFamily: 'Pretendard',
-                      fontSize: 18,
-                      fontWeight: FontWeight.w600,
-                      color: PeeroreumColor.gray[600]),
-                ),
-              ],
-            ),
-            GestureDetector(
-                onTap: () {
-                  Get.to(() => const InWedu());
-                },
-                child: Text('전체보기',
-                    style: TextStyle(
-                        fontFamily: 'Pretendard',
-                        fontWeight: FontWeight.w600,
-                        fontSize: 14,
-                        color: PeeroreumColor.gray[500])))
-          ],
-        ),
-      ),
     );
   }
 
@@ -1200,3 +1197,4 @@ class _HomeWeduState extends State<HomeWedu> {
     super.dispose();
   }
 }
+

--- a/lib/screens/wedu/wedu_home.dart
+++ b/lib/screens/wedu/wedu_home.dart
@@ -425,6 +425,23 @@ class _HomeWeduState extends State<HomeWedu> {
                     color: PeeroreumColor.black,
                   ),
                 ),
+                if (inRoomData.isNotEmpty) ...[
+                  const SizedBox(height: 20),
+                  GestureDetector(
+                    onTap: () => Get.to(() => CreateWedu()),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 8, horizontal: 16),
+                      decoration: BoxDecoration(
+                        color: PeeroreumColor.primaryPuple[400],
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: const T4_16px(
+                          text: '같이방 만들러 가기',
+                          color: PeeroreumColor.white),
+                    ),
+                  ),
+                ],
               ],
             ),
           )


### PR DESCRIPTION
- 리스트 아래 스크롤 시 참여 중인 같이방 카드 자동 접힘
- 리스트 맨 위 도달 시 카드 자동 펼쳐짐
- 참여 중인 같이방 영역 및 같이방/필터 영역 수직 스와이프로 접기/펼치기 가능
- 참여 중인 같이방 타이틀, 같이방 섹션, 필터는 항상 고정 표시
- 필터 하단 구분선은 리스트 스크롤 중일 때만 표시
- AnimatedContainer 기반 부드러운 전환 애니메이션 적용